### PR TITLE
Make version and app version optional for `out`

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,12 @@
 FROM alpine/helm:3.2.4
-RUN apk add --no-cache bash git jq aws-cli
+
+RUN apk add --no-cache \
+		bash \
+		git \
+		jq \
+		aws-cli \
+	&& apk add --no-cache --repository=http://dl-cdn.alpinelinux.org/alpine/edge/community yq
+
 RUN helm plugin install https://github.com/hypnoglow/helm-s3.git --version 0.10.0
+
 COPY bin /opt/resource

--- a/README.md
+++ b/README.md
@@ -26,8 +26,8 @@ Packages and uploads a chart to S3, updating `index.yaml` in the root of the rep
 #### Parameters
 
 * `chart`: *Required* The chart directory.
-* `version_file`: *Required* File containing chart version.
-* `app_version_file`: *Required* File containing app version. 
+* `version_file`: *Optional* File containing chart version. If omitted, `version` is read from `Chart.yaml`.
+* `app_version_file`: *Optional* File containing app version. If omitted, `appVersion` is read from `Chart.yaml`.
 
 ## Example Configuration
 

--- a/bin/config
+++ b/bin/config
@@ -2,23 +2,32 @@ config=$(cat)
 
 echo $config > /tmp/source_vars
 
+log() {
+  args=("$@")
+  echo -e "${args[@]}${NC}" 1>&2 
+}
+
 export AWS_ACCESS_KEY_ID=$(echo $config | jq -r ".source.aws_access_key_id")
 export AWS_SECRET_ACCESS_KEY=$(echo $config | jq -r ".source.aws_secret_access_key")
 S3_BUCKET_NAME=$(echo $config | jq -r ".source.s3_bucket_name")
 export AWS_DEFAULT_REGION=$(aws s3api get-bucket-location --bucket $S3_BUCKET_NAME | jq -r '.LocationConstraint // "us-east-1"')
 S3_BUCKET_PATH=$(echo $config | jq -r ".source.s3_bucket_path")
-CHART_NAME=$(echo $config | jq -r ".source.chart_name")
+CHART_NAME=$(echo $config | jq -r ".source.chart_name // empty" | sed 's/^null$//')
+
+if [ -z $CHART_NAME ]
+then
+  log "😵$RED .source.chart_name is required"
+  exit 1
+fi
+
+log "Got chart name '$CHART_NAME'"
 
 
 RED='\033[0;31m'
 GREEN='\033[0;32m'
 NC='\033[0m'
 
-log() {
-  args=("$@")
-  echo -e "${args[@]}${NC}" 1>&2 
-}
-
-log "Configuring local chart repo"
 REPO_ADDRESS=s3://${S3_BUCKET_NAME}/${S3_BUCKET_PATH}
+log "Configuring local chart repo 's3' with URI $REPO_ADDRESS"
+
 helm repo add s3 ${REPO_ADDRESS} 1>&2

--- a/bin/out
+++ b/bin/out
@@ -11,31 +11,40 @@ cd "$1"
 
 # shellcheck disable=SC2154
 CHART_DIR=$(echo "$config" | jq -r ".params.chart")
-CHART_VERSION=$(echo "$config" | jq -r ".params.version_file" | xargs cat)
-CHART_APP_VERSION=$(echo "$config" | jq -r ".params.app_version_file" | xargs cat)
+CHART_YAML_FILE=$CHART_DIR/Chart.yaml
 
-CHART_YAML_FILE=Chart.yaml
-CHART_YAML=${CHART_DIR}/${CHART_YAML_FILE}
-
-if [ ! -f ${CHART_YAML} ]
+if [ ! -f $CHART_YAML_FILE ]
 then
-  log "😵 $RED$CHART_YAML_FILE$NC not found in $CHART_DIR"
+  log "😵$RED file $CHART_YAML_FILE not found."
   exit 1
 fi
 
+CHART_VERSION_FILE=$(echo "$config" | jq -r ".params.version_file // empty" | sed 's/^null$//')
+CHART_APP_VERSION_FILE=$(echo "$config" | jq -r ".params.app_version_file // empty" | sed 's/^null$//')
+
+log "chart version file: $CHART_VERSION_FILE"
+log "chart app version file: $CHART_APP_VERSION_FILE"
+
+CHART_VERSION=$([ ! -z $CHART_VERSION_FILE ] && cat $CHART_VERSION_FILE || yq e '.version' $CHART_YAML_FILE)
+CHART_APP_VERSION=$([ ! -z $CHART_APP_VERSION_FILE ] && cat $CHART_APP_VERSION_FILE || yq e '.appVersion' $CHART_YAML_FILE)
+
+log "chart version: $CHART_VERSION"
+log "chart app version: $CHART_APP_VERSION"
+
 function readChartName {
-  helm show chart ${CHART_DIR} | grep "^name: " | cut -d' ' -f2
+  helm show chart $CHART_DIR | yq e '.name' -
 }
 
+# If chart name set and differs from Chart.yaml, update Chart.yaml
 EFFECTIVE_CHART_NAME=$(readChartName)
 if [[ "$CHART_NAME" != "$EFFECTIVE_CHART_NAME" ]]
 then
   log "⚠️ Chart name $RED$EFFECTIVE_CHART_NAME$NC in $CHART_YAML_FILE does not match config. Overriding with $GREEN$CHART_NAME$NC..."
-  sed -i '/^name:/d' ${CHART_YAML}
-  echo -e "\nname: $CHART_NAME" >> ${CHART_YAML}
+  sed -i '/^name:/d' ${CHART_YAML_FILE}
+  echo -e "\nname: $CHART_NAME" >> ${CHART_YAML_FILE}
   if [[ "$CHART_NAME" != "$(readChartName)" ]]
   then
-    log "😵😵😵 Failed setting chart name $RED$CHART_NAME$NC in $RED$$CHART_YAML"
+    log "😵😵😵 Failed setting chart name $RED$CHART_NAME$NC in $RED$$CHART_YAML_FILE"
     exit 1
   fi
 else


### PR DESCRIPTION
I make it so that version file and app version will be read from Chart.yaml if not specified as `version_file` and `app_version_file` params.
